### PR TITLE
Max Refresh Interval

### DIFF
--- a/backend/Functions/Edna.AssignmentLearnContent/Edna.AssignmentLearnContent/Startup.cs
+++ b/backend/Functions/Edna.AssignmentLearnContent/Edna.AssignmentLearnContent/Startup.cs
@@ -32,11 +32,17 @@ namespace Edna.AssignmentLearnContent
             builder.Services.AddAutoMapper(GetType().Assembly);
             
             builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+            {
+                AutomaticRefreshInterval = TimeSpan.MaxValue
+            });
             
             if (Environment.GetEnvironmentVariable("B2CConfigurationUrl") != null)
                 builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+                {
+                    AutomaticRefreshInterval = TimeSpan.MaxValue
+                });
         }
     }
 }

--- a/backend/Functions/Edna.AssignmentLinks/Edna.AssignmentLinks/Startup.cs
+++ b/backend/Functions/Edna.AssignmentLinks/Edna.AssignmentLinks/Startup.cs
@@ -29,11 +29,17 @@ namespace Edna.AssignmentLinks
             builder.Services.AddAutoMapper(GetType().Assembly);
             
             builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+            {
+                AutomaticRefreshInterval = TimeSpan.MaxValue
+            });
             
             if (Environment.GetEnvironmentVariable("B2CConfigurationUrl") != null)
                 builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+                {
+                    AutomaticRefreshInterval = TimeSpan.MaxValue
+                });
         }
     }
 }

--- a/backend/Functions/Edna.Assignments/Edna.Assignments/Startup.cs
+++ b/backend/Functions/Edna.Assignments/Edna.Assignments/Startup.cs
@@ -29,11 +29,17 @@ namespace Edna.Assignments
             builder.Services.AddAutoMapper(GetType().Assembly);
             
             builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+            {
+                AutomaticRefreshInterval = TimeSpan.MaxValue
+            });
             
             if (Environment.GetEnvironmentVariable("B2CConfigurationUrl") != null) 
                 builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+                {
+                    AutomaticRefreshInterval = TimeSpan.MaxValue
+                });
         }
     }
 }

--- a/backend/Functions/Edna.Platforms/Edna.Platforms/Startup.cs
+++ b/backend/Functions/Edna.Platforms/Edna.Platforms/Startup.cs
@@ -29,11 +29,17 @@ namespace Edna.Platforms
             builder.AddLtiAdvantageBindings();
             
             builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+            {
+                AutomaticRefreshInterval = TimeSpan.MaxValue
+            });
             
             if (Environment.GetEnvironmentVariable("B2CConfigurationUrl") != null) 
                 builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+                {
+                    AutomaticRefreshInterval = TimeSpan.MaxValue
+                });
         }
     }
 }

--- a/backend/Functions/Edna.Users/Edna.Users/Startup.cs
+++ b/backend/Functions/Edna.Users/Edna.Users/Startup.cs
@@ -34,11 +34,17 @@ namespace Edna.Users
             builder.Services.AddAutoMapper(GetType().Assembly);
             
             builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                Environment.GetEnvironmentVariable("ADConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+            {
+                AutomaticRefreshInterval = TimeSpan.MaxValue
+            });
             
             if (Environment.GetEnvironmentVariable("B2CConfigurationUrl") != null) 
                 builder.Services.AddSingleton((s) => new ConfigurationManager<OpenIdConnectConfiguration>(
-                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever()));
+                    Environment.GetEnvironmentVariable("B2CConfigurationUrl"), new OpenIdConnectConfigurationRetriever())
+                {
+                    AutomaticRefreshInterval = TimeSpan.MaxValue
+                });
         }
     }
 }

--- a/backend/Utils/Edna.Utils.Http/Edna.Utils.Http/HttpHeadersExtensions.cs
+++ b/backend/Utils/Edna.Utils.Http/Edna.Utils.Http/HttpHeadersExtensions.cs
@@ -22,8 +22,8 @@ namespace Edna.Utils.Http
         private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new JwtSecurityTokenHandler();
 
         public static async Task<bool> ValidateToken(this IHeaderDictionary headers, 
-            ConfigurationManager<OpenIdConnectConfiguration> adConfigurationManager, 
-            ConfigurationManager<OpenIdConnectConfiguration> b2CConfigurationManager, 
+            IConfigurationManager<OpenIdConnectConfiguration> adConfigurationManager, 
+            IConfigurationManager<OpenIdConnectConfiguration> b2CConfigurationManager, 
             string validAudience, Action<string> logAction = null)
         {
             if (!headers.ContainsKey("Authorization"))
@@ -36,13 +36,11 @@ namespace Edna.Utils.Http
             var token = authorizationContent?.Split(' ')[1];
             try
             {
-                adConfigurationManager.AutomaticRefreshInterval = TimeSpan.MaxValue;
                 var adConfig = await adConfigurationManager.GetConfigurationAsync(default);
                 var signingKeys = adConfig.SigningKeys;
                 var validIssuers = new List<string> { adConfig.Issuer };
                 if (b2CConfigurationManager != null)
                 {
-                    b2CConfigurationManager.AutomaticRefreshInterval = TimeSpan.MaxValue;
                     var b2CConfig = await b2CConfigurationManager.GetConfigurationAsync(default);
                     foreach (var key in b2CConfig.SigningKeys)
                         signingKeys.Add(key);


### PR DESCRIPTION
1. Set the refresh interval of configuration managers to be the max value at the creation time.
2. Rollback HttpHeadersExtensions.cs to pass the unit tests