### PR TITLE
merge in changes to enforce b2c name as lower case

### DIFF
--- a/deployment/B2CDeployment.ps1
+++ b/deployment/B2CDeployment.ps1
@@ -70,7 +70,14 @@ try{
     }
     #endregion
 
-    $B2cTenantNameFull = Read-Host "Please enter your B2C tenant name (including its extension)"
+    $B2cTenantNameFull = Read-Host "Please enter your B2C tenant name (including its extension, e.g. 'tenantname.onmicrosoft.com')"
+
+    #forcing the user to use an all lowercase name due to case sensitivity issues in the redirect URL
+    while($B2cTenantNameFull -cne $B2cTenantNameFull.ToLower()){
+        # ... so ask user to input a new b2cTenantName
+        $B2cTenantNameFull = READ-HOST "The B2C tenant you are using must be named in all lowercase; please create a new b2c tenant in ALL LOWER CASE (e.g. 'tenantname.onmicrosoft.com')"
+    }
+
     $B2cTenantName = $B2cTenantNameFull.split('.')[0]
 
     #region "B2C STEP 1: Create Active Directory application"

--- a/deployment/B2CDeployment.ps1
+++ b/deployment/B2CDeployment.ps1
@@ -72,7 +72,7 @@ try{
 
     $B2cTenantNameFull = Read-Host "Please enter your B2C tenant name (including its extension, e.g. 'tenantname.onmicrosoft.com')"
 
-    #forcing the user to use an all lowercase name due to case sensitivity issues in the redirect URL
+    #forcing the user to use an all lowercase name due to case sensitivity issues (the Redirect URL for Moodle must be all lower case)
     while($B2cTenantNameFull -cne $B2cTenantNameFull.ToLower()){
         # ... so ask user to input a new b2cTenantName
         $B2cTenantNameFull = READ-HOST "The B2C tenant you are using must be named in all lowercase; please create a new b2c tenant in ALL LOWER CASE (e.g. 'tenantname.onmicrosoft.com')"

--- a/deployment/B2CDeployment.ps1
+++ b/deployment/B2CDeployment.ps1
@@ -70,7 +70,7 @@ try{
     }
     #endregion
 
-    $B2cTenantNameFull = Read-Host "Please enter your B2C tenant name (including its extension, e.g. 'tenantname.onmicrosoft.com')"
+    $B2cTenantNameFull = Read-Host "Please enter your B2C tenant name (including its extension, e.g. 'tenantname.onmicrosoft.com')" 
 
     #forcing the user to use an all lowercase name due to case sensitivity issues (the Redirect URL for Moodle must be all lower case)
     while($B2cTenantNameFull -cne $B2cTenantNameFull.ToLower()){

--- a/docs/B2C_Deployment.md
+++ b/docs/B2C_Deployment.md
@@ -6,7 +6,7 @@ This document will explain the steps that contain user interaction and what is r
 
 * You should have already created on Azure:
   * 1x AD tenant
-  * 1x B2C tenant (when creating it on Azure portal, the name given MUST be in **all lower case**)
+  * 1x B2C tenant (when creating it on Azure portal, the name given MUST be in **all lower case**. This is because the redirect URL for Moodle that is manually inputted later must be in all lower case, and it includes the b2c tenant name.)
       * If not already set up information is available [here](https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant) at step 1: "Create an Azure AD B2C Tenant"
       * **IMPORTANT: In the current version custom domains are NOT supported, i.e. your tenant domain must be in the DEFAULT format of <code>b2cTenantName.onmicrosoft.com</code>**
 * You should have ready a **list of the tenant id's for the tenants you wish to give access**

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -14,8 +14,8 @@ To begin, you will need:
 - [Powershell](https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7?WT.mc_id=learnlti-github-cxa)
 - [Git](https://git-scm.com/downloads)
 - An Azure subscription
-- If you are running this on MacOS you also require an additional dependency of [WSMan]([)](https://www.oasys.net/fragments/powershell-on-macos-wsman/)
-- If you are running this with your choice as 'B2C' you will need to create a B2C Tenant to hold the auth resources with its name in **all lower case**
+- If you are running this with your choice as 'B2C' you will need to create a [B2C Tenant](https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant) to hold the auth resources with its name in **all lower case**. This is because the redirect URL for Moodle that is manually inputted later must be in all lower case, and it includes the b2c tenant name.
+- If you are running this on MacOS you also require an additional dependency of [WSMan](https://www.oasys.net/fragments/powershell-on-macos-wsman/)
 
 **Note:** Please ensure you **reboot your machine** after the installation of the Prerequisities
 


### PR DESCRIPTION
Modified docs to explain to user the created b2c tenant MUST have an all lower case name and the reason why (redirect URL).

Modified b2c deploy script to remind user that they must be using an all lower case tenant name when running the script; giving them a chance to reinput the name (either to correct the typo or create a new one that is all lower case) instead of crashing the script.